### PR TITLE
Allow the script to be run by the one-liner in the docs.

### DIFF
--- a/script/prepare-pi.sh
+++ b/script/prepare-pi.sh
@@ -19,7 +19,7 @@ fi
 echo "$overlay" | sudo tee -a /boot/config.txt
 
 # Prompt user to select device type
-read -p "Install for hotspots (h) or repeater boards (r)? " choice
+read -p "Install for hotspots (h) or repeater boards (r)? " choice < /dev/tty
 if [ "$choice" = "h" ]; then
     sudo mkdir -p /opt/centrunk
     cd /opt/centrunk


### PR DESCRIPTION
Without this change, the script itself becomes stdin which confuses the read command - but only when using the one-liner:

```
wget -qO- https://raw.githubusercontent.com/Centrunk/centrunk.github.io/main/script/prepare-pi.sh | sudo bash -
```

This change forces it to use /dev/tty which will ensure it works in both scenarios.